### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-01 - Skip to Main Content Accessibility
+**Learning:** The React Layout component should feature an accessible 'Skip to main content' link. When implementing this, the target main container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without jarring visual artifacts, and the link should only become visible upon focus via a smooth transition.
+**Action:** Always ensure skip links have a matching `id` target on the main content area, with programmatic focus handled carefully to avoid visual outline issues.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,9 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>Skip to main content</a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the global `Layout` component.
🎯 **Why**: Users navigating via keyboard or screen readers often have to tab through repetitive navigation links on every page before reaching the primary content. A skip link provides a direct shortcut, drastically improving usability for these users.
📸 **Before/After**: The link remains completely hidden off-screen until it receives keyboard focus, at which point it slides into view gracefully at the top left of the screen.
♿ **Accessibility**: 
- Added an anchor tag targeting the `#main-content` section.
- Ensured the `<main>` element correctly receives programmatic focus without a jarring visual ring (`tabIndex={-1}`, `outline: 'none'`).
- The link becomes visible on focus, ensuring sighted keyboard users are aware of the shortcut.

---
*PR created automatically by Jules for task [14509814046180073975](https://jules.google.com/task/14509814046180073975) started by @msacks2692-sudo*