### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-02 - Skip to Content Accessibility
+**Learning:** Screen reader users and keyboard navigators benefit greatly from a "Skip to main content" link as the first focusable element. Using `transform: translateY(-100%)` visually hides it until focused (`:focus`), providing a smooth UX without disrupting the initial layout. To make the target focusable without a visible outline artifact, the target needs `tabIndex={-1}` and `style={{ outline: 'none' }}`.
+**Action:** Always implement a visually hidden skip link and ensure the target section smoothly handles programmatic focus.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) translateY(-100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  transition: transform 0.2s ease-in-out;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.skipLink:focus {
+  transform: translateX(-50%) translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link to the application layout.
🎯 Why: To improve accessibility for screen reader and keyboard-only users by allowing them to bypass repetitive navigation links.
📸 Before/After: Visual changes demonstrated via playwright script and verified locally. The button appears at the top on focus and is hidden otherwise.
♿ Accessibility: Improves WCAG compliance. Keyboard-navigable. Programmatic focus handled gracefully without visual artifacts on the target section.

---
*PR created automatically by Jules for task [7624632964317640160](https://jules.google.com/task/7624632964317640160) started by @msacks2692-sudo*