### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-05 - Skip to Main Content Link
+**Learning:** Adding an accessible 'Skip to main content' link is essential for keyboard and screen reader users to bypass repetitive navigation links. Visually hiding it with `transform: translateY(-100%)` and revealing it on `:focus` ensures it doesn't clutter the UI for mouse users. The target `<main>` tag must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without jarring visual artifacts.
+**Action:** Always include a skip link in the main layout component of applications to improve keyboard navigation accessibility.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 100;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+import '@testing-library/jest-dom';
+
+describe('Layout component', () => {
+  it('renders a skip to main content link', () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skipLink).toBeInTheDocument();
+    expect(skipLink).toHaveAttribute('href', '#main-content');
+  });
+
+  it('renders the main content area with proper accessibility attributes', () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const mainContent = screen.getByRole('main');
+    expect(mainContent).toBeInTheDocument();
+    expect(mainContent).toHaveAttribute('id', 'main-content');
+    expect(mainContent).toHaveAttribute('tabIndex', '-1');
+    expect(mainContent).toHaveStyle({ outline: 'none' });
+  });
+});


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the primary layout component that visually reveals itself when focused.
🎯 **Why**: Improves navigation for keyboard and screen-reader users by allowing them to bypass the navigation links and jump straight to the page content.
♿ **Accessibility**: Enhanced keyboard navigation with focus states; configured the main content container to accept programmatic focus without showing an ugly outline outline.

---
*PR created automatically by Jules for task [7721037483647218489](https://jules.google.com/task/7721037483647218489) started by @msacks2692-sudo*