### PR TITLE
🎨 Palette: Add skip to main content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-04 - Skip to Main Content Accessibility
+**Learning:** A "Skip to main content" link is a critical accessibility feature for keyboard users to bypass repetitive navigation. The target container (usually `<main>`) must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without showing an unwanted default browser focus outline when navigated to via the skip link. The link itself should be visually hidden off-screen (e.g., `transform: translateY(-100%)`) until focused (`:focus`), where it slides into view.
+**Action:** Always include a visually hidden, focusable skip link at the top of the layout and ensure the target element has `tabIndex={-1}` and outline styling managed to provide a seamless transition for keyboard navigation.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 build/
 dist/
 .env
+*.log

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,23 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 3px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
This PR adds a critical accessibility feature: a "Skip to main content" link. This allows keyboard users and screen readers to bypass repetitive navigation (like the Navbar). The logic is safe and introduces no regressions. The proper use of `tabIndex={-1}` and `style={{ outline: 'none' }}` on the `<main>` element ensures that programmatic focus is received correctly without showing an ugly default focus ring on the entire page wrapper.

Includes a journal update for Palette's micro-UX learnings, and properly ignores local log files in `.gitignore`.

---
*PR created automatically by Jules for task [2081540144391951788](https://jules.google.com/task/2081540144391951788) started by @msacks2692-sudo*