### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-10 - Skip to Content Linking
+**Learning:** An accessible 'Skip to main content' link that is visually hidden off-screen (e.g., `transform: translateY(-100%)`) until focused is a crucial accessibility pattern. The target main container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without jarring visual artifacts.
+**Action:** Always include an accessible skip link for keyboard users at the layout level of web applications.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,23 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.2s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link that is visually hidden off-screen until focused by keyboard navigation.
🎯 Why: Without a skip link, keyboard and screen reader users must tab through the entire navigation menu on every page load to reach the main content. This small addition significantly improves accessibility by providing a quick bypass.
♿ Accessibility: Improves WCAG 2.4.1 Bypass Blocks compliance. Ensures the target container gracefully accepts focus without jarring visual outlines.

---
*PR created automatically by Jules for task [9731292138496426756](https://jules.google.com/task/9731292138496426756) started by @msacks2692-sudo*