### PR TITLE
🎨 Palette: Add skip to main content link for keyboard accessibility

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,22 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) translateY(-100%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateX(-50%) translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a "Skip to main content" link to the global `Layout` component that allows keyboard-only and screen reader users to bypass the navigation bar.

🎯 **Why:** Users relying on keyboard navigation must tab through the entire `Navbar` on every single page load before reaching the main content. This creates a tedious and frustrating user experience.

📸 **Before/After:** The link remains completely invisible to mouse users. For keyboard users, pressing `Tab` immediately upon page load slides down a high-contrast skip link.

♿ **Accessibility:**
- Follows the Web Content Accessibility Guidelines (WCAG) 2.4.1 (Bypass Blocks).
- Correctly targets the main content area by allowing it to programmatically receive focus (`tabIndex={-1}`) without showing a persistent focus ring.

---
*PR created automatically by Jules for task [13848290695845683905](https://jules.google.com/task/13848290695845683905) started by @msacks2692-sudo*