### PR TITLE
🎨 Palette: Add accessible skip to content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-08 - Skip to Main Content Link
+**Learning:** The React Layout component needs an accessible 'Skip to main content' link. When implementing this, the link should be visually hidden off-screen (e.g., `transform: translateY(-100%)`) until focused to avoid cluttering the UI. Crucially, the target main container must have an `id` (e.g., `id='main-content'`), `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without jarring visual artifacts when navigated to via the keyboard.
+**Action:** Always implement skip links at the start of the layout and ensure the target element can smoothly receive programmatic focus.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0%);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link that is visually hidden until focused, allowing users to bypass the navigation.
🎯 Why: Keyboard and screen reader users often have to tab through numerous navigation links before reaching the primary content, which is a frustrating experience.
📸 Before/After: Added screenshot demonstrating the focused state of the skip link in PR artifacts.
♿ Accessibility: The target main element uses `tabIndex={-1}` and `style={{ outline: 'none' }}` to ensure seamless programmatic focus without jarring visual artifacts.

---
*PR created automatically by Jules for task [6860205933283284617](https://jules.google.com/task/6860205933283284617) started by @msacks2692-sudo*