### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2024-04-09 - Accessible Skip Link
+**Learning:** A "Skip to main content" link is a critical accessibility feature. To implement it cleanly without disrupting layout, visually hide it off-screen (`transform: translateY(-100%)`) and translate it into view on `:focus`. The target main container MUST have `tabIndex={-1}` and `style={{ outline: 'none' }}` to smoothly accept programmatic focus without showing a confusing focus ring to non-keyboard users.
+**Action:** Implement this pattern for all main layouts to support screen readers and keyboard navigation effectively.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -6,8 +6,11 @@ import styles from './Layout.module.css';
 function Layout() {
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link to the global layout that smoothly receives programmatic focus.
🎯 Why: To allow keyboard navigators and screen reader users to bypass repetitive navigation links (like the navbar) and jump straight to the main content area, a critical web accessibility standard.
📸 Before/After: See verified screenshot.
♿ Accessibility: Ensures the link is visually hidden until focused, and that the `<main>` area accepts focus (`tabIndex={-1}`) without displaying an unwanted focus ring (`outline: none`).

---
*PR created automatically by Jules for task [14926081476336202736](https://jules.google.com/task/14926081476336202736) started by @msacks2692-sudo*