### PR TITLE
🎨 Palette: Add skip to main content link for keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-10 - Skip to Content Focus Management
+**Learning:** React Single Page Applications (SPAs) often fail to shift actual keyboard focus when using native hash links (e.g., `<a href="#main-content">`), even if the URL updates. The `tabIndex="-1"` and `outline: 'none'` on the `<main>` tag is necessary to gracefully receive programmatic focus without showing an ugly ring around the layout wrapper.
+**Action:** Always include an `onClick` handler on "Skip to content" links to explicitly call `.focus()` on the target element in SPAs, and ensure the target has `tabIndex="-1"` and `style={{ outline: 'none' }}`.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -4,10 +4,25 @@ import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    const mainContent = document.getElementById('main-content');
+    if (mainContent) {
+      mainContent.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" tabIndex="-1" style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,18 @@
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  top: 0;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a visually hidden "Skip to main content" link at the top of the `Layout` component that becomes visible when it receives keyboard focus.

🎯 **Why:** Keyboard-only users and screen reader users shouldn't have to tab through the entire navigation menu every time they load a new page. This provides a fast track directly to the primary content.

📸 **Before/After:** The link remains off-screen until a user presses `Tab` upon page load, at which point it slides smoothly down into view. Pressing `Enter` correctly shifts focus to the main content container without an ugly focus ring.

♿ **Accessibility:**
*   Improves keyboard navigation efficiency.
*   Uses `tabIndex="-1"` and `outline: 'none'` on the `<main>` container to gracefully handle programmatic focus.
*   Addresses React SPA routing limitations by explicitly calling `.focus()` on click rather than relying solely on native hash routing.

---
*PR created automatically by Jules for task [3818782456463219678](https://jules.google.com/task/3818782456463219678) started by @msacks2692-sudo*