### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-11 - Skip to Content Accessibility in React SPAs
+**Learning:** The native hash link behavior (`href="#main-content"`) often fails to correctly shift keyboard focus in React Single Page Applications (SPAs).
+**Action:** When implementing 'Skip to main content' links in React, use an `onClick` handler to programmatically call `.focus()` on the target container. Ensure the target has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,18 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s;
+}
+
+.skipLink:focus {
+  top: 0;
+}


### PR DESCRIPTION
💡 **What**: Added a visually hidden "Skip to main content" link at the top of the layout that becomes visible on keyboard focus. It uses programmatic focus handling to ensure it works smoothly in a React SPA.

🎯 **Why**: Keyboard and screen reader users need a way to bypass repetitive navigation links on every page load to quickly access the primary content.

♿ **Accessibility**: Provides immediate keyboard navigation to the `<main>` container. Mitigates the common SPA issue where native hash links fail to actually shift keyboard focus, ensuring true accessibility.

---
*PR created automatically by Jules for task [11160324423753445350](https://jules.google.com/task/11160324423753445350) started by @msacks2692-sudo*