### PR TITLE
🎨 Palette: Add accessible "Skip to main content" link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+## 2026-04-12 - 'Skip to content' Accessibility
+**Learning:** Native hash links in React SPAs often fail to correctly shift keyboard focus. The React Layout component features an accessible 'Skip to main content' link hidden off-screen until focused, with an `onClick` handler to programmatically call `.focus()` on the main container. The target main container must have an `id` (e.g., `id='main-content'`), `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always use an explicit `onClick` handler with `.focus()` and ensure the target has `tabIndex={-1}` when implementing skip links in React SPAs.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--primary-color, #ff4b4b);
+  color: white;
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+  text-decoration: none;
+}
+
+.skipLink:focus {
+  top: 0;
+}


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link to the main Layout component. It is visually hidden until focused via keyboard navigation.
🎯 **Why:** To improve keyboard accessibility. In React SPAs, native hash links often fail to move actual keyboard focus. This implementation programmatically shifts focus to the `<main>` container so keyboard users can bypass the top navigation.
📸 **Before/After:** See the verification screenshot for the focused state.
♿ **Accessibility:**
- Added a functional skip link.
- Used `tabIndex={-1}` and `outline: 'none'` on the target container to receive programmatic focus cleanly without disrupting mouse users.

---
*PR created automatically by Jules for task [6322800277853795507](https://jules.google.com/task/6322800277853795507) started by @msacks2692-sudo*