### PR TITLE
🎨 Palette: [Add accessible "Skip to main content" link]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-13 - SPA Skip Link Accessibility
+**Learning:** Native hash links (`href="#id"`) in React SPAs often fail to correctly shift keyboard focus, which breaks the fundamental purpose of a "Skip to main content" link for screen reader and keyboard users.
+**Action:** When implementing skip links in SPAs, use an `onClick` handler to programmatically call `.focus()` on the target container using a `useRef`. The target container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipClick}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 1000;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+
+describe('Layout Component', () => {
+  it('renders skip link and focuses main content on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skipLink).toBeInTheDocument();
+
+    const mainContent = document.getElementById('main-content');
+    expect(mainContent).toBeInTheDocument();
+
+    // It should not be focused initially
+    expect(mainContent).not.toHaveFocus();
+
+    await user.click(skipLink);
+
+    // After clicking the skip link, main content should have focus
+    expect(mainContent).toHaveFocus();
+  });
+});


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link to the main application layout.
🎯 Why: This allows keyboard and screen reader users to bypass repetitive navigation links, a critical WCAG accessibility requirement. Native hash links often fail to shift focus in React SPAs, so this implementation uses programmatic focus via `useRef`.
📸 Before/After: The link is hidden off-screen visually but slides down smoothly into view when a user focuses it using the `Tab` key.
♿ Accessibility: Improves primary keyboard navigation and screen reader support. Recorded learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [17824303396229385116](https://jules.google.com/task/17824303396229385116) started by @msacks2692-sudo*