### PR TITLE
🎨 Palette: Add skip to main content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-15 - React SPA Skip Links Accessibility
+**Learning:** Native HTML hash links (`<a href="#content">`) often fail to correctly shift keyboard focus in React Single Page Applications (SPAs). Even if the URL hash changes, the actual browser focus might not move, leaving screen reader users and keyboard navigators trapped or confused.
+**Action:** Always implement a programmatic `onClick` handler for skip links in React that manually calls `.focus()` on the target container. Ensure the target container has an `id`, `tabIndex={-1}` (so it can receive focus without being in the natural tab order), and `style={{ outline: 'none' }}` to avoid visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -4,10 +4,21 @@ import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    const mainContent = document.getElementById('main-content');
+    if (mainContent) {
+      mainContent.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--secondary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  top: 0;
+  outline: 2px solid var(--primary-color);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a "Skip to main content" link that is visually hidden until focused, allowing users to jump directly to the `<main>` container. Implemented a custom programmatic focus handler to ensure focus is actually moved in the React SPA.
🎯 **Why:** To improve keyboard navigation and screen reader accessibility by allowing users to bypass repetitive navigation elements.
♿ **Accessibility:** This directly addresses WCAG 2.4.1 (Bypass Blocks).

_Note: This fulfills a micro-UX enhancement as the agent Palette._

---
*PR created automatically by Jules for task [1028571587854126145](https://jules.google.com/task/1028571587854126145) started by @msacks2692-sudo*