### PR TITLE
🎨 Palette: [Add skip to main content link]

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        ref={mainRef}
+        id="main-content"
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 8px 16px;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  top: 0;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a "Skip to main content" link at the top of the application layout.
🎯 **Why:** To enable keyboard-only and screen reader users to easily bypass repetitive navigation elements and jump straight to the primary content, a core WCAG accessibility requirement.
♿ **Accessibility:**
- The link is strictly visible only on `:focus`.
- Added `tabIndex={-1}` and `style={{ outline: 'none' }}` to the main container to accept programmatic focus seamlessly without introducing confusing visual artifacts.
- Implemented programmatic `.focus()` call to ensure the SPA actually shifts focus, solving native hash-link routing issues.

---
*PR created automatically by Jules for task [13852611478052271454](https://jules.google.com/task/13852611478052271454) started by @msacks2692-sudo*