### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-12 - SPA Keyboard Navigation Accessibility
+**Learning:** In React Single Page Applications (SPAs), native hash links (like `href="#main-content"`) often fail to correctly shift keyboard focus to the target element due to the virtual DOM structure.
+**Action:** Always combine the hash link with an `onClick` handler that calls `.focus()` on a `useRef` referencing the target container. The target container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--secondary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s;
+  text-decoration: none;
+}
+
+.skipLink:focus {
+  top: 0;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a "Skip to main content" link at the top of the Layout that is visually hidden until focused via keyboard navigation.
🎯 **Why:** To allow keyboard and screen reader users to easily bypass repetitive navigation links and jump directly to the primary page content.
📸 **Before/After:** The link is invisible unless focused, and then it smoothly drops down from the top.
♿ **Accessibility:** This directly addresses WCAG 2.4.1 (Bypass Blocks). I also implemented a specific click handler using a `useRef` to programmatically shift focus to the `<main>` container, resolving a known issue where React SPAs fail to shift true keyboard focus with simple native `#hash` links.

---
*PR created automatically by Jules for task [7496591158258907154](https://jules.google.com/task/7496591158258907154) started by @msacks2692-sudo*