### PR TITLE
🎨 Palette: Add skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-17 - Skip Link Focus in React SPAs
+**Learning:** In React SPAs, native hash links (e.g., `<a href="#main">`) often fail to correctly shift keyboard focus to the target element due to client-side routing and virtual DOM updates.
+**Action:** Always include an `onClick` handler on "Skip to content" links to programmatically call `.focus()` on the target container via a `useRef`. The target container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,18 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  top: 0;
+}


### PR DESCRIPTION
💡 What: Added a visually hidden "Skip to main content" link to the main Layout component that becomes visible upon keyboard focus.
🎯 Why: Improves keyboard accessibility by allowing screen reader users and keyboard navigators to bypass repetitive navigation links (Navbar) and jump straight to the main page content.
📸 Before/After: Screenshot showing the link appearing on tab focus included in verification.
♿ Accessibility: The target main container has `tabIndex={-1}` and `style={{ outline: 'none' }}` to gracefully accept programmatic focus without ugly browser default focus rings, as native hash links often fail in React SPAs.

---
*PR created automatically by Jules for task [763849895827501821](https://jules.google.com/task/763849895827501821) started by @msacks2692-sudo*