### PR TITLE
🎨 Palette: [Skip to Content Link Accessibility]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-05 - SPA Skip to Content Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, an `onClick` handler is needed to programmatically call `.focus()` on the target container. The target container must have an `id` (e.g., `id='main-content'`), a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always use programmatic focus management with a React `ref` for skip-to-content links in SPAs to ensure robust keyboard accessibility.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,18 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--secondary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  top: 0;
+}


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link at the very top of the DOM structure in `Layout.js`, alongside the required CSS for focus-driven visibility and a programmatic focus handler.
🎯 Why: Keyboard and screen-reader users need a way to bypass repetitive navigation links (like the Navbar) to jump straight to the primary page content. React SPA routing often breaks native `#hash` anchors, requiring manual `.focus()` management.
📸 Before/After: Visual changes only appear on <kbd>Tab</kbd> press, revealing a secondary-colored link banner.
♿ Accessibility: Ensures WCAG 2.4.1 (Bypass Blocks) compliance, massively improving usability for keyboard-only and assistive technology users navigating TrueLinks.

---
*PR created automatically by Jules for task [18342440582653632596](https://jules.google.com/task/18342440582653632596) started by @msacks2692-sudo*