### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-19 - Skip to Main Content Link Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus to the target section. When implementing accessible 'Skip to main content' links, the target container must explicitly be made focusable using `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus without visual artifacts.
+**Action:** Always include an `onClick` handler on "skip to" links to programmatically call `.focus()` on the target container using a React `ref`.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} ref={mainRef} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,18 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s;
+}
+
+.skipLink:focus {
+  top: 0;
+}


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link at the very top of the DOM.
🎯 **Why**: In React SPAs, keyboard users often have to tab through repetitive navigation elements (like the Navbar) on every single page view. A skip link allows them to bypass the navigation and go straight to the main content.
♿ **Accessibility**: Implements a standard WCAG skip navigation technique. It uses a programmatic focus shift via a React `ref` and `tabIndex={-1}` because native hash anchors (e.g., `#main-content`) notoriously fail to move keyboard focus reliably in React Router applications.

---
*PR created automatically by Jules for task [11219424212415186119](https://jules.google.com/task/11219424212415186119) started by @msacks2692-sudo*