### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-15 - React SPA Skip Links
+**Learning:** Native hash links (`<a href="#main-content">`) in React Single Page Applications often fail to correctly shift keyboard focus because of how the router handles navigation.
+**Action:** When implementing accessible "Skip to main content" links in a React SPA, include an `onClick` handler to programmatically call `.focus()` on the target container. Ensure the target container has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,18 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--secondary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.2s;
+}
+
+.skipLink:focus {
+  top: 0;
+}


### PR DESCRIPTION
* 💡 What: Added an accessible "Skip to main content" link to the layout.
* 🎯 Why: To allow keyboard users and screen readers to bypass the navigation and jump straight to the main page content, improving overall accessibility.
* 📸 Before/After: The link is visually hidden by default and becomes visible when it receives keyboard focus.
* ♿ Accessibility: Addresses a WCAG requirement for skipping repetitive navigation. Included a specific workaround (programmatic `focus()`) for a known React SPA hash link routing issue.

---
*PR created automatically by Jules for task [4580667069664923368](https://jules.google.com/task/4580667069664923368) started by @msacks2692-sudo*