### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-22 - Accessible Skip Link Focus Management
+**Learning:** In React SPAs, native hash links (e.g., `href="#main-content"`) often fail to reliably shift keyboard focus to the target element due to the absence of full page reloads and how React handles routing. This causes subsequent keyboard navigation to continue from the link's location rather than the target.
+**Action:** When implementing 'Skip to main content' links, combine the `href` with an `onClick` handler to programmatically call `.focus()` on the target container. Ensure the target container is configured to receive programmatic focus smoothly by giving it an `id`, a React `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to prevent visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,24 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  font-weight: bold;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  border-bottom-right-radius: var(--border-radius);
+  text-decoration: none;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link that appears on keyboard focus. It bypasses the navigation and jumps straight to the main content area.
🎯 **Why**: In SPAs with navigation menus, keyboard and screen reader users have to tab through all navigation links on every page change. This skip link provides a shortcut to the primary content, significantly improving efficiency and reducing fatigue for keyboard-only users.
♿ **Accessibility**: 
- Added a semantically correct skip link.
- Handled React SPA routing quirks by programmatically shifting focus to the `<main>` container using `ref` and `tabIndex={-1}`.
- Ensured the link is visually hidden but slides down visibly when focused via keyboard.

---
*PR created automatically by Jules for task [7852672337953530116](https://jules.google.com/task/7852672337953530116) started by @msacks2692-sudo*