### PR TITLE
🎨 Palette: Add skip-to-main-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2025-01-28 - React SPA Skip Link Focus
+**Learning:** In React SPAs, native hash links often fail to shift keyboard focus accurately due to dynamic rendering. A "Skip to main content" link needs an `onClick` handler to programmatically focus the target `<main>` container using a `ref`. The container must also have `tabIndex={-1}` and `style={{ outline: 'none' }}` to smoothly accept focus.
+**Action:** When adding skip links, ensure programmatic focus handling is implemented rather than relying solely on native HTML anchor links. Apply CSS `transform: translateY` for smooth reveal/hide transitions.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,22 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a visually hidden "Skip to main content" link at the top of the page. It smoothly slides down into view when focused via keyboard navigation, and programmatically shifts focus to the `<main>` container when activated.

🎯 **Why:** Keyboard users and screen reader users need a way to bypass repetitive navigation links (like the Navbar) and jump straight to the primary content on each page load.

📸 **Before/After:** No visual change for mouse users. Keyboard users will now see a "Skip to main content" link slide down when tabbing from the top of the document.

♿ **Accessibility:** This solves a critical WCAG requirement (Bypass Blocks). It also handles a known React SPA issue where native hash links sometimes fail to update keyboard focus properly by using a `useRef` and `focus()` call.

---
*PR created automatically by Jules for task [17431143831649239381](https://jules.google.com/task/17431143831649239381) started by @msacks2692-sudo*