### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-24 - Skip Link Accessibility in SPAs
+**Learning:** In React SPAs, native hash links (like `<a href="#main">`) often fail to correctly shift keyboard focus because there is no actual page reload. This leaves screen reader users stranded at the top of the document even if the visual viewport shifts.
+**Action:** When implementing accessible "Skip to main content" links in SPAs, include an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without generating an unwanted visual focus ring.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        onClick={handleSkip}
+        className={styles.skipLink}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,23 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 100;
+  transition: transform 0.3s ease-in-out;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added a "Skip to main content" link to the main Layout component that becomes visible upon receiving keyboard focus. It programmatically shifts focus to the `<main>` content area.

🎯 **Why**: In single-page applications, native hash links often fail to shift actual keyboard focus. This implementation ensures keyboard and screen reader users can efficiently bypass repetitive top-level navigation on every page.

♿ **Accessibility**: 
- Added `skipLink` CSS class to visually hide the link until it receives `:focus`.
- The `<main>` container now has `tabIndex={-1}` and an `onClick` handler on the link calls `.focus()` to programmatically move the user's active element, resolving SPA focus issues.

---
*PR created automatically by Jules for task [11957575672421139287](https://jules.google.com/task/11957575672421139287) started by @msacks2692-sudo*