### PR TITLE
🎨 Palette: Add 'Skip to main content' accessibility link

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToMain}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        ref={mainRef}
+        id="main-content"
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,22 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 8px 16px;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link to the application's layout.
🎯 Why: Keyboard and screen reader users need a way to bypass repetitive navigation blocks to reach the main content directly.
📸 Before/After: (See Playwright screenshot from verification - link appears smoothly on keyboard focus)
♿ Accessibility: Improves WCAG compliance for bypass blocks. Implemented carefully to prevent React SPA router side-effects by programmatically focusing the main container while hiding its focus ring.

---
*PR created automatically by Jules for task [3575335610558361866](https://jules.google.com/task/3575335610558361866) started by @msacks2692-sudo*