### PR TITLE
🎨 Palette: Add Skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-25 - React Hash Links Focus
+**Learning:** In React SPAs, native hash links often fail to shift focus properly, requiring an `onClick` handler with programmatic `.focus()`. To smoothly transition off-screen skip links into view, `transform: translateY(0)` on `:focus` ensures keyboard navigators can access the main content area seamlessly.
+**Action:** Always implement an `onClick` handler with programmatic `.focus()` on a target container with `tabIndex={-1}` and `style={{ outline: 'none' }}` for accessible 'Skip to main content' links in React SPAs.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  text-decoration: none;
+  font-weight: bold;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 1000;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+
+describe('Layout component skip link', () => {
+  it('focuses main content when skip link is clicked', () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const skipLink = screen.getByText('Skip to main content');
+    const mainContent = document.getElementById('main-content');
+
+    expect(skipLink).toBeInTheDocument();
+    expect(mainContent).toBeInTheDocument();
+    expect(mainContent).toHaveAttribute('tabIndex', '-1');
+
+    fireEvent.click(skipLink);
+
+    expect(mainContent).toHaveFocus();
+  });
+});


### PR DESCRIPTION
💡 **What**: Added a "Skip to main content" link to the main Layout component for keyboard accessibility.
🎯 **Why**: Navigating past repeated navigation links (like the navbar) on every page load is extremely tedious for keyboard-only users and screen reader users. Standard hash links (e.g. `#main-content`) often fail to correctly shift the focus state in React SPAs, so this implements programmatic focus shift using a ref and an `onClick` handler.
♿ **Accessibility**: Keyboard and screen reader users can now seamlessly tab to the "Skip to main content" link as the first focusable element on the page, and executing it will smoothly transition their keyboard focus directly into the main content area for an improved and more efficient browsing experience.

---
*PR created automatically by Jules for task [6637638897402654376](https://jules.google.com/task/6637638897402654376) started by @msacks2692-sudo*