### PR TITLE
🎨 Palette: Add accessible skip to content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2024-05-02 - Accessible Skip to Content Link in React SPAs
+**Learning:** Native hash links for "Skip to main content" often fail to shift keyboard focus in React SPAs. Elements need programmatic focus via `ref.current.focus()`. Furthermore, to accept programmatic focus smoothly without a visual outline, the target container must have `tabIndex={-1}` and `style={{ outline: 'none' }}`. Skip links are best hidden visually but kept accessible using `transform: translateY(-100%)` for default state, and transitioning to `transform: translateY(0)` on `:focus`.
+**Action:** When implementing skip links in React, always use an `onClick` handler with a `useRef` to programmatically focus the target main container rather than relying entirely on native `href="#id"` anchor links. Hide the link using CSS transform to avoid taking up visual space until it receives focus.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link that appears on keyboard focus.
🎯 Why: Keyboard-only and screen reader users need a way to bypass repetitive navigation blocks to reach the main content quickly. Native hash links often fail in React SPAs, so programmatic focus is used.
📸 Before/After: The link is visually hidden off-screen by default and slides into view upon receiving keyboard focus.
♿ Accessibility: Improves WCAG compliance by allowing users to skip navigation via keyboard. Uses `tabIndex={-1}` and `outline: 'none'` to accept programmatic focus smoothly without visual artifacts.

---
*PR created automatically by Jules for task [13324116828751332881](https://jules.google.com/task/13324116828751332881) started by @msacks2692-sudo*