### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-08 - Skip Link Focus Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus to the target container. When implementing accessible "Skip to main content" links, programmatic focus is required.
+**Action:** Include an `onClick` handler on the skip link to programmatically call `.focus()` on the target container's `ref`. Ensure the target container (e.g., `<main>`) has an `id`, `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to smoothly accept focus without visual artifacts. Hide the skip link visually using `transform: translateY(-100%)` and show on focus with `transform: translateY(0)` to ensure a smooth CSS transition.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        className={styles.mainContent}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,23 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateY(-100%) translateX(-50%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0) translateX(-50%);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added a visually hidden "Skip to main content" link at the top of the application layout that slides into view upon receiving keyboard focus. Clicking it programmatically shifts focus to the main content container.
🎯 **Why:** To significantly improve keyboard navigation and accessibility, allowing screen reader and keyboard-only users to easily bypass repetitive header navigation and jump straight to the primary content of the page.
♿ **Accessibility:**
- Added `href="#main-content"` skip link as the first focusable element.
- Managed React SPA routing focus explicitly by utilizing `useRef` and `.focus()`, because native hash links often fail to shift actual keyboard focus in SPAs.
- Added `tabIndex={-1}` and `style={{ outline: 'none' }}` to the `<main>` container to accept programmatic focus without introducing visual artifacts.
- Ensured smooth appearance via CSS transitions, maintaining a sleek, tangible feel.

---
*PR created automatically by Jules for task [6012949073437130250](https://jules.google.com/task/6012949073437130250) started by @msacks2692-sudo*