### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+## 2026-05-04 - Programmatic Focus for React SPA Skip Links
+**Learning:** In React SPAs, native hash links (e.g. `#main-content`) often fail to correctly shift keyboard focus because the router interrupts the default browser behavior. This causes screen readers to remain at the top of the page.
+**Action:** When implementing 'Skip to content' links in SPAs, always include an `onClick` handler to programmatically call `.focus()` on the target container. Ensure the target container has a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,20 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 **What:** Adds a "Skip to main content" link as the first focusable element on the page. It is visually hidden but slides into view when focused via keyboard navigation. When clicked/activated, it programmatically shifts focus to the main content area.

🎯 **Why:** To improve accessibility for keyboard and screen reader users. The application is a Single Page Application (SPA), meaning that without a skip link, users would have to tab through the entire navigation menu on every page load to reach the primary content. The programmatic focus is necessary because standard hash links often fail to shift focus properly in React routing setups.

📸 **Before/After:** The link appears dynamically at the top left of the screen during initial tab navigation.

♿ **Accessibility:**
- Added `a` tag at the start of the DOM with `href="#main-content"`.
- Uses `tabIndex={-1}` and `style={{ outline: 'none' }}` on the `<main>` element to allow it to receive programmatic focus smoothly without a visual focus ring.
- Utilizes `useRef` to programmatically move focus to circumvent React Router focus handling issues.

---
*PR created automatically by Jules for task [1961156189383828418](https://jules.google.com/task/1961156189383828418) started by @msacks2692-sudo*