### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-05 - Skip to Content Accessibility in SPAs
+**Learning:** In React SPAs, native hash links (e.g., `href="#main-content"`) often fail to correctly shift keyboard focus due to how React handles routing and DOM updates. A visually hidden "Skip to main content" link must programmatically shift focus to the target container using a React `ref` and `.focus()`. The target container needs `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without showing an unseemly outline.
+**Action:** When implementing accessible "Skip to main content" links in SPAs, combine `href` with an `onClick` handler to manually manage focus via `useRef`, and use CSS `transform: translateY(...)` for off-screen hiding and focus revelation.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem 1.5rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  font-weight: bold;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link to the main application layout.

🎯 Why: In single-page applications, keyboard and screen reader users often have to tab through repetitive navigation links on every page load. This hidden link allows them to bypass the navigation and jump straight to the primary content of the view, a crucial accessibility feature.

📸 Before/After: Before, tab navigation would go straight to the TrueLinks logo. After, the first tab press focuses and visually reveals the "Skip to main content" link at the top of the screen.

♿ Accessibility:
- Added a visually hidden link that is revealed on `:focus`.
- Used `tabIndex={-1}` and `style={{ outline: 'none' }}` on the `<main>` container to allow programmatic focus without showing an ugly default focus ring.
- Used `useRef` to programmatically shift focus because native hash links (`href="#main-content"`) often fail to move actual keyboard focus in React SPAs.

---
*PR created automatically by Jules for task [14142311208772352702](https://jules.google.com/task/14142311208772352702) started by @msacks2692-sudo*