### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-06 - Skip to Content Focus in React
+**Learning:** Native hash links often fail to correctly shift keyboard focus in React SPAs. When implementing accessible "Skip to main content" links, programmatic focus via `ref.current.focus()` is required. The target container must have `tabIndex={-1}` to accept focus without visual artifacts (using `style={{ outline: 'none' }}`).
+**Action:** Always implement programmatic focus and `tabIndex={-1}` for internal skip links in React applications.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main ref={mainRef} id="main-content" className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the main application layout.
🎯 **Why**: Navigating single-page apps via keyboard can be tedious if users must tab through the entire navigation menu on every route change. This provides a standard accessibility mechanism to bypass the header.
♿ **Accessibility**: Implements a visually hidden skip link that becomes visible on focus. Uses a React ref to programmatically shift keyboard focus to the main `<main>` container, resolving standard React SPA hash link focus issues. The container is given `tabIndex={-1}` to accept programmatic focus without showing a persistent focus outline for mouse users.

---
*PR created automatically by Jules for task [13069958204712097685](https://jules.google.com/task/13069958204712097685) started by @msacks2692-sudo*