### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-07 - React SPA Skip Link Accessibility
+**Learning:** Native hash links often fail to shift keyboard focus in React SPAs. When implementing 'Skip to main content' links, an `onClick` handler is required to programmatically call `.focus()` on the target container. The container must have a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.
+**Action:** Always use programmatic focus management for in-page navigation links in React applications.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,23 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    mainRef.current.focus();
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipClick}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} tabIndex={-1} className={styles.mainContent} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,20 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link that bypasses the navigation menu and brings focus directly to the main content area.
🎯 Why: In Single Page Applications (SPAs) like React, native hash links often fail to shift keyboard focus, requiring users who rely on keyboards to tab through the entire navigation on every page load. This enhancement correctly implements programmatic focus to solve that problem.
📸 Before/After: Screenshots and verification video attached to local verification records.
♿ Accessibility: Drastically improves keyboard navigation and screen reader efficiency by allowing users to bypass repetitive navigation links.

Recorded the learning about programmatic focus management for React SPA hash links in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [14928321060718487398](https://jules.google.com/task/14928321060718487398) started by @msacks2692-sudo*