### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-10 - Skip to Main Content Link Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible "Skip to main content" links, it is necessary to include an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always implement programmatic focus management for skip links in single-page applications.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = () => {
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToContent}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link to the Layout component that programmatically shifts focus to the main content area.
🎯 Why: In React Single Page Applications (SPAs), native hash links often fail to correctly shift keyboard focus. This programmatic focus management ensures that screen reader and keyboard-only users can reliably bypass the navigation menu and jump straight to the primary content, significantly improving the app's accessibility and adherence to WCAG guidelines.
♿ Accessibility:
- Implemented a visually hidden, focusable skip link at the top of the DOM.
- Used a React `ref` and `onClick` handler to programmatically apply focus to the `<main>` container.
- Added `tabIndex={-1}` and `style={{ outline: 'none' }}` to the target container to allow it to receive programmatic focus smoothly without showing an awkward outline box to mouse users.

---
*PR created automatically by Jules for task [15950668297760783310](https://jules.google.com/task/15950668297760783310) started by @msacks2692-sudo*