### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-10 - Skip Link React Focus
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus to the target section, making "Skip to main content" links ineffective for keyboard users without a full page reload.
+**Action:** To implement accessible skip links in React, use an `onClick` handler to programmatically call `.focus()` on a `useRef` pointing to the target container. The target must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to smoothly accept focus.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 100;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link that appears on keyboard focus and programmatically shifts focus to the `<main>` element when clicked.
🎯 Why: Native anchor hashes often fail to correctly move keyboard focus in Single Page Applications like React, preventing keyboard/screen-reader users from bypassing repetitive navigation components.
📸 Before/After: Visuals verified via Playwright screenshot where skip link slides into view on Tab focus.
♿ Accessibility: Uses an absolute positioned, visually hidden link, applies programmatic focus via React ref, and sets target tabIndex={-1} with no outline to smoothly shift reading order focus natively.

---
*PR created automatically by Jules for task [3972876954825851448](https://jules.google.com/task/3972876954825851448) started by @msacks2692-sudo*