### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-12 - Accessible SPA Routing
+**Learning:** Native hash links often fail to shift keyboard focus in React SPAs. An accessible 'Skip to main content' link must programmatically call `.focus()` on its target.
+**Action:** Use a React `useRef`, set `tabIndex={-1}` and `outline: 'none'` on the target container, and handle the `onClick` event on the link to manually shift focus.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToContent}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        className={styles.mainContent}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link that appears on keyboard focus.
🎯 **Why:** To allow keyboard and screen-reader users to bypass repetitive navigation links (like the Navbar) and jump straight to the primary content of the page, which is a WCAG accessibility standard.
📸 **Before/After:** The link remains visually hidden until focused via the 'Tab' key, then slides down from the top of the screen.
♿ **Accessibility:** Solved the React SPA issue where native hash links fail to shift focus by implementing programmatic focus management (`useRef` and `.focus()`) on the `<main>` container, configured with `tabIndex={-1}` and `outline: 'none'` to accept focus gracefully.

---
*PR created automatically by Jules for task [18348875905807971924](https://jules.google.com/task/18348875905807971924) started by @msacks2692-sudo*