### PR TITLE
🎨 Palette: Add accessible 'Skip to main content' link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-15 - React Router Hash Links and Accessibility
+**Learning:** Native hash links (e.g., `<a href="#main-content">`) in React Single Page Applications often fail to correctly shift keyboard focus to the target element due to router-based navigation overriding native browser behavior. This causes screen readers and keyboard users to lose their place when using "Skip to main content" links.
+**Action:** When implementing accessible "Skip to main content" links in React, always include an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainContentRef}
+        tabIndex={-1}
+        className={styles.mainContent}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  font-weight: bold;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+
+describe('Layout component', () => {
+  it('should shift focus to the main content area when the skip link is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const skipLink = screen.getByText('Skip to main content');
+    const mainContent = screen.getByRole('main');
+
+    expect(skipLink).toBeInTheDocument();
+    expect(mainContent).toBeInTheDocument();
+
+    // Verify initial focus is not on main
+    expect(mainContent).not.toHaveFocus();
+
+    // Click the skip link
+    await userEvent.click(skipLink);
+
+    // Verify focus has shifted to the main content
+    expect(mainContent).toHaveFocus();
+  });
+});


### PR DESCRIPTION
💡 **What:** Added an accessible 'Skip to main content' link to the layout. It's visually hidden but animates in when focused via keyboard navigation.
🎯 **Why:** Allows keyboard and screen reader users to easily bypass repeated navigation links on the TrueLinks SPA and jump straight to the content.
📸 **Before/After:** No visual changes for non-keyboard users.
♿ **Accessibility:** Added the link and correctly managed focus (using `useRef`) for robust behavior inside the React Router SPA, resolving common issues where native hash links fail to trigger focus shift inside an app. Added an automated test for this programmatic focus change.

---
*PR created automatically by Jules for task [16966636111123671637](https://jules.google.com/task/16966636111123671637) started by @msacks2692-sudo*