### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-04 - React SPA Skip to Content Accessibility
+**Learning:** In React Single Page Applications, native hash links (e.g. `<a href="#main">`) often fail to reliably shift keyboard focus to the target container, breaking the "Skip to Content" accessibility requirement.
+**Action:** Always implement an explicit `onClick` handler on "Skip to Content" links that programmatically calls `.focus()` on the main container's ref. The main container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to gracefully receive focus without showing visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToContent}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 100;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link to the global `Layout` component that appears when focused via keyboard navigation.
🎯 **Why:** To allow keyboard-only and screen reader users to easily bypass repetitive navigation blocks (like the Navbar) and jump straight to the primary page content, significantly improving efficiency and adhering to accessibility best practices.
📸 **Before/After:** No visual changes unless navigating via keyboard (Tab key), which reveals the skip link at the top of the page.
♿ **Accessibility:** Added programmatic focus shifting in React to handle focus correctly for SPA routing, ensuring that activating the link reliably moves focus to the `<main>` container for subsequent navigation.

---
*PR created automatically by Jules for task [8263842058239010091](https://jules.google.com/task/8263842058239010091) started by @msacks2692-sudo*