### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-15 - Skip to Main Content Link in SPAs
+**Learning:** In React SPAs, native hash links (like `<a href="#main-content">`) often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, an `onClick` handler is necessary to programmatically call `.focus()` on the target container.
+**Action:** Always ensure the target container (e.g., `<main>`) has an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link to the global layout.
🎯 Why: Keyboard users and screen reader users need a way to bypass repetitive navigation blocks (like the Navbar) to jump straight to the primary page content.
♿ Accessibility: The link is visually hidden but becomes visible when it receives keyboard focus, avoiding visual clutter while providing critical accessibility. It utilizes programmatic focus to guarantee the container correctly receives the target focus in an SPA environment.

---
*PR created automatically by Jules for task [4464456476585249985](https://jules.google.com/task/4464456476585249985) started by @msacks2692-sudo*