### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-16 - Skip Link Accessibility in React SPAs
+**Learning:** Native hash links (e.g., `<a href="#main-content">`) often fail to correctly shift keyboard focus in React Single Page Applications. The visual scroll might happen, but the keyboard focus remains on the triggering link, defeating the purpose of a "Skip to content" link.
+**Action:** Always use an `onClick` handler to programmatically focus the target container using a React `useRef`. Ensure the target container has `id="main-content"`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to smoothly accept programmatic focus without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,22 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) translateY(-100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateX(-50%) translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
## 💡 What
Added a "Skip to main content" link to the global application layout.

## 🎯 Why
Keyboard-only users and screen reader users need an efficient way to bypass repetitive navigation elements to reach the primary content on each page. Native hash links often fail to shift focus properly in React SPAs, so this implements programmatic focus management.

## 📸 Before/After
Before: Keyboard users must tab through the entire top navigation on every page load.
After: The first tab stop focuses a visible link at the top of the screen that shifts focus directly to the main content container.

## ♿ Accessibility
- Implements WCAG 2.4.1 (Bypass Blocks).
- Safely manages focus in a React SPA using `useRef` and `tabIndex={-1}`.

---
*PR created automatically by Jules for task [12285550738452109095](https://jules.google.com/task/12285550738452109095) started by @msacks2692-sudo*