### PR TITLE
🎨 Palette: [Add skip to main content link]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-04 - Skip to Main Content Link Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus to the target section. A "Skip to main content" link must not only jump to an element but actually programmatically call `.focus()` on the target. The target element must be focusable using `tabIndex={-1}` and styled with `outline: none` so that normal keyboard navigation can continue smoothly without visual focus rings on non-interactive containers.
+**Action:** Implement "Skip to main content" links with an `onClick` handler utilizing `useRef` to programmatically focus the target `<main>` container, ensuring it accepts focus smoothly.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link to the main Layout component.
🎯 Why: Allows keyboard and screen reader users to bypass the navigation menu and jump straight to the page's primary content, significantly improving navigation efficiency.
📸 Before/After: The link remains hidden until the user presses the 'Tab' key, upon which it slides smoothly into view from the top left corner.
♿ Accessibility: The link is visually hidden until focused via keyboard. It uses React `useRef` to programmatically call `.focus()` on the main container because native hash links often fail to shift focus properly in React Single Page Applications (SPAs). The main container receives `tabIndex={-1}` and `outline: none` to accept this programmatic focus gracefully without displaying a persistent focus ring.

---
*PR created automatically by Jules for task [15628151089923474084](https://jules.google.com/task/15628151089923474084) started by @msacks2692-sudo*