### PR TITLE
🎨 Palette: [Skip to content link]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-05 - Skip to Content Accessibility in React
+**Learning:** In React SPAs, native hash links (like `<a href="#main">`) often fail to properly shift keyboard focus, leaving screen reader users stuck at the top of the document even if the viewport scrolls.
+**Action:** When implementing 'Skip to content' links in React, always include an `onClick` handler that programmatically calls `.focus()` on a `useRef` attached to the target container. Ensure the target container has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipLinkClick = () => {
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipLinkClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 **What**: Added an accessible 'Skip to main content' link to `Layout.js`.
🎯 **Why**: To allow keyboard-only and screen-reader users to bypass repetitive navigation links (the navbar) and jump directly to the primary page content. This is a crucial accessibility requirement.
♿ **Accessibility**: Implemented programmatic focus using a React `useRef` to handle shifting focus to the `<main>` container properly, addressing native hash link issues in React SPAs. The target receives `tabIndex={-1}` and `outline: 'none'` to accept focus smoothly without unwanted visual artifacts. The skip link is kept hidden off-screen until it receives focus.

---
*PR created automatically by Jules for task [5861908594074422424](https://jules.google.com/task/5861908594074422424) started by @msacks2692-sudo*