### PR TITLE
🎨 Palette: Add accessible skip-to-main-content link

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" onClick={handleSkipToContent} className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+
+describe('Layout component', () => {
+  it('renders skip to main content link', () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skipLink).toBeInTheDocument();
+  });
+
+  it('focuses main content when skip link is clicked', () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    const mainContent = document.getElementById('main-content');
+
+    expect(document.activeElement).not.toBe(mainContent);
+
+    fireEvent.click(skipLink);
+
+    expect(document.activeElement).toBe(mainContent);
+  });
+});


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the primary layout component.
🎯 **Why**: Navigating complex interfaces (like a dating application dashboard) can be tedious for keyboard-only and screen reader users who must tab through the entire navigation bar repeatedly. This provides a direct path to the core content. Drawing inspiration from clear spatial referencing in sign language interpretation and heads-up displays in game design, this acts as a critical, immediate signpost that puts the user back in control of their spatial context without cognitive overload.
📸 **Before/After**: See the attached screenshots in the UI verification artifacts. Before, tabbing placed the user onto the TrueLinks logo. After, the first tab stop drops down a highly visible 'Skip to main content' link.
♿ **Accessibility**: Implements WCAG guideline 2.4.1 (Bypass Blocks). Uses a tested `useRef` based focus approach that fixes known SPA issues where native hash links fail to reliably shift screen reader focus. Also styled safely using CSS pseudo-classes to avoid DOM style mutation.

---
*PR created automatically by Jules for task [2213765127354280966](https://jules.google.com/task/2213765127354280966) started by @msacks2692-sudo*