### PR TITLE
🎨 Palette: [Add Skip to Main Content Link]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-10 - SPA Skip Link Accessibility
+**Learning:** In React SPAs, native hash links (e.g., `<a href="#main-content">`) often fail to correctly shift keyboard focus to the target element due to routing/rendering cycles.
+**Action:** When implementing 'Skip to main content' links, always include an `onClick` handler to programmatically call `.focus()` on a `useRef` attached to the target container. Ensure the target has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link at the top of the DOM.
🎯 Why: In Single Page Applications (SPAs), native hash anchors sometimes fail to correctly shift keyboard focus. The programmatic focus implementation ensures keyboard and screen reader users can efficiently bypass repeated navigation menus.
♿ Accessibility: The link is hidden for mouse users and becomes visible purely upon receiving keyboard focus, and successfully passes focus to the `<main>` container properly labeled with `tabIndex={-1}` to avoid standard outline outlines.

---
*PR created automatically by Jules for task [1159166146122114259](https://jules.google.com/task/1159166146122114259) started by @msacks2692-sudo*