### PR TITLE
🎨 Palette: Add accessible skip to content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-18 - Skip Link Accessibility in React SPAs
+**Learning:** Native hash links often fail to move keyboard focus reliably in React Single Page Applications.
+**Action:** When implementing "Skip to content" links, use an `onClick` handler with a `ref` to programmatically call `.focus()` on the main container. The container needs `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToMain}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,23 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) translateY(-100%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  transition: transform 0.3s ease;
+}
+
+.skipLink:focus {
+  transform: translateX(-50%) translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the main `Layout` component that smoothly transitions into view on keyboard focus. Also added programmatic focus management on click to bypass native hash link limitations in SPAs.
🎯 **Why**: Allows keyboard and screen reader users to bypass repetitive navigation links (like the top Navbar) and jump straight to the primary page content. This is a critical accessibility standard (WCAG 2.4.1 Bypass Blocks).
♿ **Accessibility**:
- Added visually hidden (off-screen) link that appears on `:focus`
- Used programmatic `.focus()` combined with `tabIndex={-1}` and `style={{outline: 'none'}}` on the main container to ensure keyboard focus successfully transfers across the single page app without displaying an ugly default outline box around the whole content area.

---
*PR created automatically by Jules for task [8630359309466644843](https://jules.google.com/task/8630359309466644843) started by @msacks2692-sudo*