### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-25 - Skip to Main Content Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible "Skip to main content" links, programmatic focus management is required to ensure screen readers and keyboard users correctly navigate to the main container.
+**Action:** Always include an `onClick` handler on the skip link to programmatically call `.focus()` on the target container. Ensure the target container has a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept focus smoothly without visual artifacts. Style the link visually hidden off-screen (`transform: translateY(-100%)`) and reveal it on `:focus` (`transform: translateY(0)`).

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  border-bottom-right-radius: var(--border-radius);
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 What: Added a visually hidden "Skip to main content" link that reveals on focus and programmatically shifts keyboard focus to the main container.
🎯 Why: In React SPAs, native hash links often fail to shift focus properly for screen reader users. This ensures keyboard-only and screen reader users can efficiently bypass the navigation menu and jump straight to the page content.
📸 Before/After: Visual verified via Playwright. Link styles use existing design system variables.
♿ Accessibility: Uses `useRef` and `tabIndex={-1}` to programmatically manage focus, bypassing typical SPA routing accessibility pitfalls.

---
*PR created automatically by Jules for task [4169245128308075518](https://jules.google.com/task/4169245128308075518) started by @msacks2692-sudo*