### PR TITLE
🎨 Palette: Add skip-to-content accessibility link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2024-05-18 - Skip to Content Link Accessibility in SPAs
+**Learning:** Native hash links for skip-to-content functionality often fail to reliably shift keyboard focus in React Single Page Applications (SPAs).
+**Action:** Implement an `onClick` handler on the skip link to programmatically call `.focus()` on the main content container. Ensure the target container has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without unwanted visual artifacts. Hide the link visually using `transform: translateY(-100%)` and show it on `:focus` with `transform: translateY(0)` to preserve accessibility while keeping the UI clean.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipLinkClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipLinkClick}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} tabIndex={-1} className={styles.mainContent} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 10px 15px;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 999;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added a "Skip to main content" link at the top of the `Layout` component that is visually hidden until focused via keyboard. Also added a programmatic `.focus()` fallback to the main container because native hash links can sometimes fail to correctly shift focus in React SPAs.

### 🎯 Why: The user problem it solves
Keyboard-only users (like those using screen readers or switch devices) otherwise have to tab through the entire navigation menu (`Navbar`) on every single page load or route change just to reach the primary content of the application. This is a massive friction point. This simple link lets them jump straight to the content.

### 📸 Before/After: Screenshots if visual change
The link is completely invisible unless a user hits `Tab` right after loading the page. When focused, it smoothly drops down from the top-left corner as a clearly visible button with high contrast. 

### ♿ Accessibility: Any a11y improvements made
- Bypassing blocks: Satisfies WCAG 2.4.1 (Bypass Blocks).
- Keyboard Navigation: Makes keyboard navigation significantly faster and less tedious.
- Programmatic Focus: Using `ref.current.focus()` along with `tabIndex={-1}` and `outline: 'none'` ensures that focus cleanly moves to the correct container without leaving weird blue focus rings around the entire main section for mouse users.

---
*PR created automatically by Jules for task [6929627345135190770](https://jules.google.com/task/6929627345135190770) started by @msacks2692-sudo*