### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-25 - Skip to Content Link Accessibility in SPAs
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus because routing intercepts the navigation. Simply linking to `#main-content` visually scrolls but doesn't move screen reader or keyboard focus.
+**Action:** When implementing 'Skip to main content' links, always use an `onClick` handler to programmatically call `.focus()` on a `useRef` pointing to the target container. The target container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus without showing a visual outline ring.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" className={styles.mainContent} ref={mainContentRef} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  z-index: 100;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added an accessible 'Skip to main content' link that bypasses React router navigation issues.
🎯 **Why**: Improves keyboard and screen reader accessibility by allowing users to skip repetitive navigation links on every page load.
♿ **Accessibility**: Applied `tabIndex={-1}` and `outline: 'none'` to the main container so it can gracefully receive programmatic focus without showing an ugly default focus ring. Recorded a learning entry about SPA native hash link limitations.

---
*PR created automatically by Jules for task [14116084529395537619](https://jules.google.com/task/14116084529395537619) started by @msacks2692-sudo*