### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToContent}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,21 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.2s ease-in-out;
+  border-bottom-right-radius: var(--border-radius);
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link to the global `Layout` component that becomes visible when focused via keyboard navigation.
🎯 **Why:** Allows keyboard users and screen reader users to easily bypass repetitive navigation links (the Navbar) and jump directly to the primary page content. This is a foundational WCAG accessibility requirement.
📸 **Before/After:** See the attached visual verification artifact. The link slides down from the top of the screen gracefully on the first `Tab` press.
♿ **Accessibility:**
- Implements standard skip link pattern.
- Uses `useRef` to programmatically shift focus to the `<main>` container, overcoming common React SPA hash link issues.
- Adds `tabIndex={-1}` and `outline: 'none'` to the container so it receives programmatic focus without disrupting the normal tab order or displaying an unsightly outline.

---
*PR created automatically by Jules for task [13875212455937216365](https://jules.google.com/task/13875212455937216365) started by @msacks2692-sudo*