### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-27 - Skip to Main Content Accessibility
+**Learning:** In React SPAs, native hash links often fail to shift keyboard focus properly. When implementing accessible 'Skip to main content' links, an `onClick` handler is needed to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts. For styling, using `transform: translateY(-100%)` for hidden and `translateY(0)` for `:focus` is an effective pattern.
+**Action:** Always include programmatic focus shifting alongside native hash anchors in React for skip links to ensure robust screen reader compatibility.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" onClick={handleSkipToContent} className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} className={styles.mainContent} tabIndex={-1} style={{ outline: 'none' }}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,21 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  text-decoration: none;
+  font-weight: bold;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+  z-index: 1000;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
**💡 What**: Added a "Skip to main content" link to the primary `Layout` component. It is visually hidden but slides down smoothly on `:focus`.
**🎯 Why**: Screen reader and keyboard-only users often have to tab through dozens of navigation links just to reach the primary content on every page load. Additionally, standard hash links (`#main-content`) are notoriously buggy in React SPAs for correctly shifting accessibility focus, which we circumvent by programmatically calling `.focus()` on the container.
**♿ Accessibility**: Implemented using the `useRef` hook to programmatically shift focus, bypassing React router hash link issues, and applying `tabIndex={-1}` on `<main>` so it can accept focus without displaying a visual focus ring.

---
*PR created automatically by Jules for task [16891066489240154654](https://jules.google.com/task/16891066489240154654) started by @msacks2692-sudo*