### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-29 - Skip to Content Link
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, include an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id` (e.g., `id='main-content'`), a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always use programmatic focus via `useRef` when implementing skip links in React applications.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main ref={mainRef} id="main-content" tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,20 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--secondary-color);
+  color: var(--white);
+  font-weight: bold;
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link at the top of the application layout that becomes visible only on keyboard focus. It uses programmatic focus to shift attention to the main content area.
🎯 Why: To improve keyboard navigation and screen reader accessibility by allowing users to bypass repetitive top-level navigation (like the Navbar) and jump directly to the primary page content. This is a crucial UX standard.
📸 Before/After: (See Playwright UI verification screenshot) The skip link is visually hidden off-screen, and elegantly transitions into view when receiving initial `Tab` focus.
♿ Accessibility: Ensures keyboard users don't have to tab through every nav link on every page load. Uses proper React `ref` programmatic focusing to ensure robust operation in an SPA context, bypassing common hash-routing focus bugs.

---
*PR created automatically by Jules for task [16194435946972359430](https://jules.google.com/task/16194435946972359430) started by @msacks2692-sudo*