### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-30 - Skip to Content Focus Management
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, native HTML anchors aren't enough. You must include an `onClick` handler to programmatically call `.focus()` on the target container. Additionally, the target container needs `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly without showing an unsightly visual ring. To keep it visually hidden but accessible, use `transform: translateY(-100%)` with absolute positioning and transition it to `translateY(0)` on `:focus`.
+**Action:** Always use a combination of `useRef`, programmatic focus, and specific container attributes (`tabIndex={-1}`, `outline: 'none'`) when implementing skip links in SPAs to ensure robust keyboard navigation.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkip}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,21 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}


### PR DESCRIPTION
### 💡 What
Added a "Skip to main content" link to the main application layout.

### 🎯 Why
Keyboard navigation in Single Page Applications (SPAs) often requires extra care because native hash links (`<a href="#main-content">`) frequently fail to properly shift focus to the content area without reloading the page. This prevents keyboard-only users and screen-reader users from easily bypassing repeated navigation blocks.

### 📸 Before/After
See attached verification artifacts indicating the element rendering on screen during `Tab` navigation.

### ♿ Accessibility
- Provides a robust mechanism for keyboard users to bypass the main navigation.
- Uses explicit focus management via `useRef` and programmatic `.focus()`.
- Updates the main container to smoothly accept focus (`tabIndex={-1}`, `outline: 'none'`) without introducing messy default focus rings to standard clicks.

---
*PR created automatically by Jules for task [4601782975681248197](https://jules.google.com/task/4601782975681248197) started by @msacks2692-sudo*