### PR TITLE
🎨 Palette: Add Accessible 'Skip to Main Content' Link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-31 - SPA Skip to Content Accessibility
+**Learning:** In React SPAs, native hash links (like `<a href="#main-content">`) often fail to correctly shift keyboard focus to the target container. Implementing accessible 'Skip to main content' links requires an `onClick` handler to programmatically call `.focus()` on a target `useRef`.
+**Action:** Always include programmatic `.focus()` alongside native `#hash` linking for skip links in SPAs. Ensure the target container has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus cleanly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 1000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import Layout from './Layout';
+
+describe('Layout component', () => {
+  it('renders skip to main content link', () => {
+    render(
+      <BrowserRouter>
+        <Layout />
+      </BrowserRouter>
+    );
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skipLink).toBeInTheDocument();
+  });
+
+  it('shifts focus to main content area when clicked', async () => {
+    render(
+      <BrowserRouter>
+        <Layout />
+      </BrowserRouter>
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    const mainContent = screen.getByRole('main');
+
+    // Simulate clicking the skip link
+    await userEvent.click(skipLink);
+
+    // Verify that focus is shifted to the main content area
+    expect(mainContent).toHaveFocus();
+  });
+});


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link that becomes visible when focused via keyboard navigation.
🎯 **Why:** To drastically improve accessibility for keyboard-only and screen-reader users, allowing them to bypass the repetitive top navigation and jump straight into the application's core content.
📸 **Before/After:** No visual changes initially. When tabbing from the URL bar, a styled skip link now smoothly drops down from the top of the screen.
♿ **Accessibility:** Solves critical navigation issues for screen readers. Handles React Single Page Application (SPA) focus quirks by correctly assigning `tabIndex={-1}` and programmatically shifting the active DOM focus to the main container.

---
*PR created automatically by Jules for task [2186980595875229227](https://jules.google.com/task/2186980595875229227) started by @msacks2692-sudo*