### PR TITLE
🎨 Palette: Add skip-to-main-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-11 - Playwright Off-Screen Element Verification
+**Learning:** Playwright's `to_be_hidden()` only checks DOM presence and basic CSS (display/visibility) and does not consider elements hidden via CSS transforms (e.g., `translateY`). To verify elements positioned off-screen visually, check their bounding box coordinates (e.g., `box['y'] < 0`).
+**Action:** Use `await locator.bounding_box()` to verify visual off-screen hidden states instead of `to_be_hidden()`.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = () => {
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        className={styles.mainContent}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,20 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  transition: transform 0.3s ease-in-out;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 10px;
+  z-index: 100;
+  left: 50%;
+  text-decoration: none;
+  border-radius: 0 0 5px 5px;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link to the global layout.
🎯 Why: Allows keyboard and screen reader users to bypass repetitive navigation elements and directly access the main content of the page, improving overall accessibility.
📸 Before/After: The link remains visually hidden off-screen until it receives keyboard focus, at which point it slides smoothly into view at the top center of the page.
♿ Accessibility: Uses `id`, `ref`, and `tabIndex={-1}` on the `<main>` container to allow programmatic focus without visual focus rings, adhering to WCAG best practices for SPAs.

---
*PR created automatically by Jules for task [17217129689215424525](https://jules.google.com/task/17217129689215424525) started by @msacks2692-sudo*