### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-15 - React SPA Skip Link Accessibility
+**Learning:** Native hash links often fail to shift keyboard focus properly in React single-page applications. When implementing a 'Skip to main content' link, it's necessary to manually trigger `.focus()` via an `onClick` handler. The target container needs `tabIndex={-1}` and `style={{ outline: 'none' }}` to smoothly accept focus.
+**Action:** Always use an explicit ref and programmatic `.focus()` combined with visually hidden accessible styling (`transform: translate(-50%, -100%)`) for skip links in React.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkip = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,22 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  transition: transform 0.3s;
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 8px 16px;
+  z-index: 100;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added a "Skip to main content" link that is visually hidden until focused via keyboard navigation, allowing screen reader and keyboard users to bypass the navigation menu and jump straight to the main page content.

🎯 **Why**: In React Single Page Applications (SPAs), native hash links often fail to shift keyboard focus accurately. This accessibility enhancement ensures users who rely on keyboard navigation aren't forced to tab through the entire navigation bar on every page load. It programmatically moves focus directly to the `<main>` container for a smoother, faster navigation experience.

♿ **Accessibility**: 
- Added a skip link at the very top of the DOM structure.
- Used programmatic `.focus()` combined with `tabIndex={-1}` on the target to guarantee focus shifts correctly in the React SPA environment.
- Styled the link to be visually hidden off-screen but elegantly slide into view when receiving focus, providing clear visual feedback without cluttering the default UI.

---
*PR created automatically by Jules for task [2256568194410744667](https://jules.google.com/task/2256568194410744667) started by @msacks2692-sudo*