### PR TITLE
🎨 Palette: Add accessible skip-to-content link for keyboard users

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-10 - Programmatic Focus for Skip Links in SPAs
+**Learning:** In React SPAs, native hash links (e.g., `<a href="#main-content">`) often fail to correctly shift keyboard focus, even if they scroll the page. When implementing accessible "Skip to main content" links, it's necessary to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always include an `onClick` handler on skip links in React applications that programmatically sets focus using a `ref` on a container with `tabIndex={-1}`.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  z-index: 100;
+  transform: translate(-50%, -100%);
+  transition: transform 0.3s ease;
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the main Layout wrapper. The link is visually hidden but slides into view upon receiving keyboard focus. It programmatically shifts focus to the `<main>` content area.
🎯 **Why**: In single-page React applications (SPAs), native hash links often fail to adequately shift programmatic focus for screen readers and keyboard users. This change ensures those users can easily bypass the `Navbar` to directly engage with the page content.
♿ **Accessibility**: 
- Provides an immediate bypass mechanism for repeating navigation links (WCAG 2.4.1 Bypass Blocks).
- Utilizes `tabIndex={-1}` and `outline: 'none'` on the `<main>` tag to safely and silently receive programmatic focus without showing a lingering browser focus ring.
- Programmatically manages focus using React `useRef` to guarantee the SPA correctly registers the focus shift.

---
*PR created automatically by Jules for task [13426620086510673362](https://jules.google.com/task/13426620086510673362) started by @msacks2692-sudo*