### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-04 - Skip to Main Content Link in React SPAs
+**Learning:** Native hash links (e.g., `<a href="#main-content">`) often fail to correctly shift keyboard focus in React Single Page Applications (SPAs).
+**Action:** When implementing accessible "Skip to main content" links, include an `onClick` handler to programmatically call `.focus()` on the target container. Ensure the target container has `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToContent}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 10px 20px;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
🎨 **Palette: Add accessible skip to main content link**

💡 **What:** Added a "Skip to main content" link that allows keyboard and screen reader users to bypass the navigation menu.

🎯 **Why:** Native hash links can sometimes fail to correctly shift programmatic focus in React Single Page Applications. This update uses a React `useRef` and `tabIndex={-1}` to explicitly focus the `<main>` container safely, allowing for a seamless keyboard navigation experience without visual artifacts.

♿ **Accessibility:** This solves a critical WCAG requirement for keyboard navigability, enabling users to jump straight to the content they care about.

📸 **Before/After:** No visual difference for mouse users. For keyboard users hitting Tab on initial load, a nicely styled (matching system colors) link drops down from the top.

---
*PR created automatically by Jules for task [4211661622978807623](https://jules.google.com/task/4211661622978807623) started by @msacks2692-sudo*