### PR TITLE
🎨 Palette: Add accessible Skip to Content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-08 - "Skip to Content" in React SPAs
+**Learning:** Native hash links (e.g., `<a href="#main">`) often fail to correctly shift keyboard focus in React Single Page Applications. The focus ring might move, but subsequent 'Tab' presses restart from the top of the document.
+**Action:** When implementing accessible "Skip to main content" links in React, always include an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToContent}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main id="main-content" ref={mainRef} tabIndex={-1} style={{ outline: 'none' }} className={styles.mainContent}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,24 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 8px;
+  z-index: 100;
+  transition: transform 0.3s;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 0 0 5px 5px;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link to the main Layout.
🎯 Why: Keyboard users and screen reader users need a way to bypass repetitive navigation links to reach the main content immediately. Native hash links often fail to shift focus properly in React SPAs, so this implements programmatic focus.
📸 Before/After: Screenshots captured in Playwright tests show it hidden normally, appearing beautifully on Tab focus.
♿ Accessibility: Major improvement for keyboard navigators, passing focus directly to the `<main>` tag.

---
*PR created automatically by Jules for task [5130951542668510593](https://jules.google.com/task/5130951542668510593) started by @msacks2692-sudo*