### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-07 - React Hash Link Focus Shifting
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, an `onClick` handler is needed to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always use a ref and programmatically trigger `.focus()` for skip links or in-page navigation in React to ensure keyboard focus actually shifts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,25 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 1rem;
+  z-index: 100;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  transition: transform 0.3s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link in the main Layout component, styled to visually slide into view only when receiving keyboard focus. It properly shifts programmatic focus to the `<main>` element to fix React SPA navigation issues.

🎯 Why: Essential accessibility feature for keyboard-only and screen reader users, allowing them to bypass the repetitive top navigation bar and go straight to the primary content of the page.

♿ Accessibility:
- Added `href="#main-content"` skip link right before the navbar.
- Implemented an `onClick` handler that calls `.focus()` via a ref on the `<main>` container to ensure React successfully shifts the keyboard focus.
- Added `id="main-content"`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to the main container so it can gracefully receive focus without displaying an unappealing focus ring.

---
*PR created automatically by Jules for task [11153681076008540025](https://jules.google.com/task/11153681076008540025) started by @msacks2692-sudo*