### PR TITLE
🎨 Palette: Skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-04-10 - Skip to Main Content Link Accessibility
+**Learning:** In React SPAs, native hash links (like `<a href="#main-content">`) often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, an `onClick` handler is needed to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always implement programmatic focus shift using `useRef` and `tabIndex={-1}` for 'Skip to content' links in SPA environments.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,24 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  transform: translate(-50%, -100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 1000;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link to the global `Layout.js` component.
🎯 **Why:** In Single Page Applications (SPAs) like React, native hash links (e.g., `#main-content`) often fail to successfully shift keyboard focus or screen reader context. This leaves users frustrated. By using programmatic focus management (`useRef` and `.focus()`), we ensure a smooth, accessible experience for all users bypassing the navigation menu.
📸 **Before/After:** See attached Playwright screenshot and video verification.
♿ **Accessibility:**
- Added a `.skipLink` that is visually hidden off-screen (`translate(-50%, -100%)`) but becomes visible on `:focus`.
- Added programmatic focus shifting to `<main id="main-content">`.
- Configured `<main>` with `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus seamlessly without displaying an ugly visual outline around the entire page body.

---
*PR created automatically by Jules for task [5299074113491167502](https://jules.google.com/task/5299074113491167502) started by @msacks2692-sudo*