### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-05-15 - Skip to Content Pattern for SPAs
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, an `onClick` handler is needed to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Implement this pattern (skip link with programmatic `.focus()` and target container with `tabIndex={-1}` and `outline: 'none'`) whenever building new SPA layouts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,30 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkip = (e) => {
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkip}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What**: Added a "Skip to main content" link to the main `Layout` component that becomes visible on keyboard focus and programmatically shifts focus to the main content area.
🎯 **Why**: In React SPAs, native hash links often fail to shift keyboard focus accurately. This ensures that keyboard and screen reader users can bypass repetitive navigation links (the Navbar) and jump straight to the content.
♿ **Accessibility**: Improved keyboard navigation significantly. Used `tabIndex={-1}` and `outline: 'none'` on the `<main>` tag to allow it to receive programmatic focus smoothly without showing an awkward outline box. Documented this critical learning in the Palette journal for future components.

---
*PR created automatically by Jules for task [8359848459835784124](https://jules.google.com/task/8359848459835784124) started by @msacks2692-sudo*