### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-11 - Programmatic Focus in React SPAs
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus. When implementing accessible 'Skip to main content' links, an `onClick` handler must be used to programmatically call `.focus()` on the target container. The target container must have an `id` (e.g., `id='main-content'`), a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always implement programmatic `.focus()` with `tabIndex={-1}` and `outline: 'none'` for skip links in React SPAs.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipToMain}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,25 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the application layout.
🎯 **Why**: To allow keyboard and screen reader users to quickly bypass repetitive navigation links (like the Navbar) and jump straight to the primary content of the page, satisfying a key accessibility standard.
📸 **Before/After**: The link is visually hidden by default. Upon pressing `Tab` on page load, it slides down from the top of the screen.
♿ **Accessibility**: 
- Added a functional `#main-content` target.
- Used a React `ref` to programmatically `focus()` the main container, resolving native SPA hash link bugs.
- Added `tabIndex={-1}` and `outline: 'none'` to the main container for a smooth focus transition.

---
*PR created automatically by Jules for task [17988476447977396100](https://jules.google.com/task/17988476447977396100) started by @msacks2692-sudo*