### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-04 - React SPA Skip to Main Content Link Accessibility
+**Learning:** In React SPAs, native hash links often fail to correctly shift keyboard focus to the target container. When implementing accessible 'Skip to main content' links, an `onClick` handler is needed to programmatically call `.focus()` on the target container. The target container must have an `id` (e.g., `id='main-content'`), a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts. For styling the skip link, use `transform: translate(-50%, -100%)` with absolute positioning and `left: 50%` to center and hide it off-screen, and `transform: translate(-50%, 0)` on `:focus` to bring it into view, ensuring smooth CSS transitions.
+**Action:** Always implement programmable focus and CSS transitions for visually hiding and showing "Skip to main content" links in React applications.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a href="#main-content" className={styles.skipLink} onClick={handleSkipClick}>
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 10px 15px;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 3px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link to the main Layout component.
🎯 **Why:** In React Single Page Applications (SPAs), native anchor hash links often fail to shift actual keyboard focus. This forces keyboard and screen reader users to tab through the entire navigation menu on every page load. This PR implements a programmatic focus shift alongside a visually hidden skip link that appears cleanly on `:focus` to drastically improve navigability.
📸 **Before/After:** The link remains completely hidden for mouse users but smoothly slides down from the top edge when a user presses 'Tab'.
♿ **Accessibility:** Fixes WCAG 2.4.1 Bypass Blocks by ensuring keyboard and screen reader users can efficiently skip to the primary content on any route.

---
*PR created automatically by Jules for task [4421498851691215444](https://jules.google.com/task/4421498851691215444) started by @msacks2692-sudo*