### PR TITLE
🎨 Palette: Add accessible "Skip to main content" link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-14 - Skip to Content Focus in React SPA
+**Learning:** Native hash links (e.g., `<a href="#main-content">`) often fail to correctly shift keyboard focus in React Single Page Applications (SPAs).
+**Action:** When implementing accessible "Skip to main content" links in React SPAs, include an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = () => {
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        onClick={handleSkipToContent}
+        className={styles.skipLink}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,25 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  font-weight: bold;
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  cursor: pointer;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 What: Added an accessible "Skip to main content" link to the global `Layout.js` component.
🎯 Why: Keyboard and screen reader users often have to tab through repetitive global navigation (like the Navbar) on every single page load before reaching the actual content. A skip link solves this major friction point.
📸 Before/After: Visualized in the frontend verification script - the link is visually hidden off-screen until it receives keyboard focus via the Tab key.
♿ Accessibility: 
- Implemented smooth programmatic `.focus()` on the main container because native hash links often fail in React SPAs.
- Added `tabIndex={-1}` and `outline: 'none'` to the main container so it can receive focus without creating an ugly visual outline.
- Used semantic `<a>` tag with fallback `href`.

---
*PR created automatically by Jules for task [15517888591565323935](https://jules.google.com/task/15517888591565323935) started by @msacks2692-sudo*