### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-05 - SPA Skip to Content Links
+**Learning:** In React SPAs, native hash links (`href="#main-content"`) often fail to properly shift keyboard focus.
+**Action:** When implementing accessible "Skip to main content" links, use an `onClick` handler to programmatically call `.focus()` on the target container. The target container must have an `id`, a `ref`, `tabIndex={-1}`, and `style={{ outline: 'none' }}` to accept programmatic focus smoothly without visual artifacts.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        className={styles.mainContent}
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,20 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  padding: 1rem 1.5rem;
+  background-color: var(--primary-color);
+  color: var(--white);
+  font-weight: bold;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link at the top of the Layout component.
🎯 **Why**: Screen reader and keyboard-only users often have to tab through repetitive navigation links on every page change. This link allows them to bypass the Navbar and jump straight to the `<main>` content area.
♿ **Accessibility**:
- Visually hidden off-screen until it receives keyboard focus, avoiding visual clutter for mouse users while providing a clear target for keyboard users.
- Uses an `onClick` handler to explicitly shift browser focus to the `<main>` element using a React `ref`, which is necessary for React SPAs since native hash links often fail to shift focus smoothly.
- `<main>` was given `tabIndex="-1"` and `style={{ outline: 'none' }}` so it can receive programmatic focus without showing an unwanted focus ring.

This micro-UX improvement ensures compliance with WCAG guidelines for bypassing repetitive content and makes keyboard navigation significantly more efficient.

---
*PR created automatically by Jules for task [13890357124232918850](https://jules.google.com/task/13890357124232918850) started by @msacks2692-sudo*