### PR TITLE
🎨 Palette: Add Skip to Main Content Link

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,37 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+      // Also update URL to #main-content
+      window.history.pushState(null, '', '#main-content');
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToMain}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        className={styles.mainContent}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,19 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-radius: var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
**💡 What:** Added an accessible "Skip to main content" link to the global Layout.
**🎯 Why:** Keyboard and screen reader users need a way to bypass repetitive navigation elements (like the Navbar) to jump straight to the primary content of the page. This is a critical WCAG accessibility requirement.
**📸 Before/After:** See the attached visual verification screenshots where the link gracefully slides into view upon receiving keyboard focus.
**♿ Accessibility:** Enhanced keyboard navigation. Ensured React SPA routing compatibility by using programmatic `.focus()` combined with `window.history.pushState()`. Removed ugly focus rings from the target `<main>` element when programmatically focused.

---
*PR created automatically by Jules for task [12121208817459483267](https://jules.google.com/task/12121208817459483267) started by @msacks2692-sudo*