### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-06-18 - Accessible SPA Skip Links
+**Learning:** Native hash links (e.g., `<a href="#main-content">`) often fail to successfully shift keyboard focus to target elements in Single Page Applications like React.
+**Action:** When implementing 'Skip to content' links in SPAs, use an `onClick` handler to programmatically call `.focus()` on the target container using a `useRef`, and update the URL using `window.history.pushState()`. The target container must have `tabIndex={-1}` and `style={{ outline: 'none' }}` to accept focus smoothly.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainContentRef = useRef(null);
+
+  const handleSkipToContent = (e) => {
+    e.preventDefault();
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+    window.history.pushState(null, '', '#main-content');
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToContent}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainContentRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,20 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 100;
+  transition: transform 0.2s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+}

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Layout from './Layout';
+
+describe('Layout Accessibility', () => {
+  test('skip link moves focus to main content', () => {
+    render(
+      <BrowserRouter>
+        <Layout />
+      </BrowserRouter>
+    );
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    const mainContent = screen.getByRole('main');
+
+    expect(skipLink).toBeInTheDocument();
+    expect(mainContent).toHaveAttribute('id', 'main-content');
+    expect(mainContent).toHaveAttribute('tabIndex', '-1');
+
+    // Initially main content should not have focus
+    expect(mainContent).not.toHaveFocus();
+
+    // Click the skip link
+    fireEvent.click(skipLink);
+
+    // Focus should move to main content
+    expect(mainContent).toHaveFocus();
+  });
+});


### PR DESCRIPTION
💡 **What:** Added a visually hidden, accessible "Skip to main content" link at the top of the application layout that becomes visible when focused via keyboard navigation.

🎯 **Why:** To improve accessibility for keyboard users and screen reader users by allowing them to bypass the navigation menu and jump straight to the primary content on each page. Native hash links often fail in SPAs, so this uses programmatic focus management.

♿ **Accessibility:**
- Follows WCAG guidelines for bypass blocks.
- Manages focus programmatically using `useRef` and `.focus()` to ensure reliable behavior in a React SPA.
- Visually hides the link off-screen until it receives focus, avoiding disruption for mouse/touch users while providing a clear visual indicator for keyboard users.

---
*PR created automatically by Jules for task [11266401495529195979](https://jules.google.com/task/11266401495529195979) started by @msacks2692-sudo*