### PR TITLE
🎨 Palette: Add accessible "Skip to main content" link

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+    window.history.pushState({}, '', '#main-content');
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,22 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--secondary-color);
+  color: var(--white);
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 1000;
+  transition: transform 0.3s ease-in-out;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What:** Added a visually hidden "Skip to main content" link at the top of the application layout that appears when focused via keyboard navigation.
🎯 **Why:** To allow keyboard and screen reader users to bypass repetitive navigation links (like the Navbar) and jump directly to the primary page content, significantly improving efficiency and usability.
♿ **Accessibility:**
- Follows WCAG best practices for skip links.
- Visually hidden off-screen by default, appears on `:focus` with a visible outline.
- Smoothly transitions programmatic focus to the `<main>` container using `useRef` and updates the URL.
- Uses `tabIndex={-1}` and `style={{ outline: 'none' }}` on the `<main>` container to accept focus without native visual artifacts.

---
*PR created automatically by Jules for task [13687038191665676426](https://jules.google.com/task/13687038191665676426) started by @msacks2692-sudo*