### PR TITLE
🎨 Palette: Add skip to main content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-16 - SPA Skip Link Accessibility Focus
+**Learning:** In React SPAs, native hash links (e.g., `<a href="#main-content">`) often fail to correctly shift keyboard focus to the target container, causing screen readers and keyboard users to lose their place.
+**Action:** When implementing 'Skip to main content' links, include an `onClick` handler to programmatically call `.focus()` on the target container using a React `ref` and update the URL history. Ensure the target has `tabIndex={-1}` and `style={{ outline: 'none' }}`.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipClick = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+    }
+    window.history.pushState(null, '', '#main-content');
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipClick}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className={styles.mainContent}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,3 +1,22 @@
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--primary-color);
+  color: var(--white);
+  padding: 8px 16px;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  z-index: 100;
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
 .mainContent {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
💡 **What**: Added an accessible "Skip to main content" link to the global `Layout` component that animates into view only when focused via keyboard.

🎯 **Why**: Improves navigation for keyboard-only and screen-reader users, allowing them to bypass the repetitive navigation bar on every page view. Also addresses the common SPA accessibility issue where native anchor links fail to programmatically focus the target element, ensuring the user actually skips the content properly.

📸 **Before/After**: The visual change only appears when using keyboard navigation (`Tab`). It smoothly drops down from the top edge of the screen to indicate focus.

♿ **Accessibility**: Adds a crucial WCAG standard feature. Uses `useRef` to manually `.focus()` the main container alongside `tabIndex={-1}` and `outline: 'none'` to guarantee focus shifting for assistive technologies without leaving visual artifacts.

---
*PR created automatically by Jules for task [4487775055910905652](https://jules.google.com/task/4487775055910905652) started by @msacks2692-sudo*