### PR TITLE
🎨 Palette: Add accessible skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-04 - Copy to Clipboard Accessibility
 **Learning:** Copy to Clipboard functionality requires a specific UX pattern: visual feedback (text change to 'Copied!'), dynamic `aria-label`, and a 2-second timeout to revert the state. Unit tests for React components relying on this require `jest.useFakeTimers()` to verify state changes securely and efficiently.
 **Action:** Always implement dynamic `aria-label` and visual feedback timeouts for copy actions, and use `jest.useFakeTimers()` for testing the reverting logic.
+
+## 2026-03-05 - SPA Focus Management for Skip Links
+**Learning:** In React Single Page Applications, native hash links (e.g. `<a href="#main-content">`) often fail to correctly shift keyboard focus because the DOM might have changed without a full page reload. To ensure accessibility, an `onClick` handler is needed to programmatically call `.focus()` on the target container and update the URL using `window.history.pushState()`. The target container must also have `tabIndex={-1}` to accept programmatic focus smoothly without visual artifacts.
+**Action:** Always combine semantic HTML `<a>` tags for skip links with an `onClick` handler for programmatic focus management in React apps. Apply `tabIndex={-1}` and `style={{ outline: 'none' }}` to the target container.

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import styles from './Layout.module.css';
 
 function Layout() {
+  const mainRef = useRef(null);
+
+  const handleSkipToMain = (e) => {
+    e.preventDefault();
+    if (mainRef.current) {
+      mainRef.current.focus();
+      window.history.pushState({}, '', '#main-content');
+    }
+  };
+
   return (
     <div>
+      <a
+        href="#main-content"
+        className={styles.skipLink}
+        onClick={handleSkipToMain}
+      >
+        Skip to main content
+      </a>
       <Navbar />
-      <main className={styles.mainContent}>
+      <main
+        id="main-content"
+        ref={mainRef}
+        className={styles.mainContent}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -3,3 +3,23 @@
   margin: 0 auto;
   padding: 2rem;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background: var(--primary-color);
+  color: var(--white);
+  padding: 1rem 1.5rem;
+  z-index: 1000;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  font-weight: bold;
+  transition: transform 0.3s ease-in-out;
+}
+
+.skipLink:focus {
+  transform: translate(-50%, 0);
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
💡 **What:** Added an accessible "Skip to main content" link to the top of the TrueLinks layout.
🎯 **Why:** Keyboard and screen-reader users need a fast way to bypass repetitive navigation links (like the navbar) and jump straight to the primary content on each page. Native hash links often fail to shift programmatic focus in Single Page Applications like React, so a targeted React solution was needed.
♿ **Accessibility:**
- The link is the first focusable element on the page.
- Visually hidden (off-screen) by default to not disrupt the visual design, but smoothly transitions into view when it receives keyboard focus.
- Implements correct SPA focus management: uses `useRef` and `.focus()` to programmatically shift focus to the `<main>` container.
- The `<main>` container has `tabIndex={-1}` and `outline: 'none'` so it can accept focus programmatically without displaying an ugly default focus ring to mouse users.

---
*PR created automatically by Jules for task [16851822628738512435](https://jules.google.com/task/16851822628738512435) started by @msacks2692-sudo*